### PR TITLE
wip: depfile fixes

### DIFF
--- a/beaker/line_counts.md
+++ b/beaker/line_counts.md
@@ -2,7 +2,7 @@
 
 - **Cutout Main Code**: 383 (Tests: 103)  
 - **Head Main Code**: 355 (Tests: 0)  
-- **Common Main Code**: 3589 (Tests: 2248)  
-- **Total Main Code (excluding build.rs)**: 4327  
-- **Total Main Code (including build.rs)**: 4486 (Reported: 4486)  
+- **Common Main Code**: 3590 (Tests: 2262)  
+- **Total Main Code (excluding build.rs)**: 4328  
+- **Total Main Code (including build.rs)**: 4487 (Reported: 4487)  
 ✅ Totals match.

--- a/beaker/tests/metadata_based_tests.rs
+++ b/beaker/tests/metadata_based_tests.rs
@@ -66,11 +66,14 @@ fn get_test_scenarios() -> Vec<TestScenario> {
                 "0.5",
                 "--crop=head",
                 "--bounding-box",
+                "--depfile",
+                "example.d",
             ],
             expected_files: vec![
                 "example.beaker.toml",
                 "example_crop.jpg",
                 "example_bounding-box.jpg",
+                "example.d",
             ],
             metadata_checks: vec![
                 MetadataCheck::ConfigValue("detect", "confidence", toml::Value::from(0.5)),
@@ -82,6 +85,7 @@ fn get_test_scenarios() -> Vec<TestScenario> {
                 MetadataCheck::ConfigValue("detect", "bounding_box", toml::Value::from(true)),
                 MetadataCheck::OutputCreated("example_crop.jpg"),
                 MetadataCheck::OutputCreated("example_bounding-box.jpg"),
+                MetadataCheck::OutputCreated("example.d"),
                 MetadataCheck::ExitCode("detect", 0),
                 MetadataCheck::CoreResultsField("detect", "detections"),
             ],


### PR DESCRIPTION
- depfiles were only generated when `--metadata` was passed
- depfiles were not tested
- TODO: `--depfile` overwrites the same file over and over when used with a batch. Should use `--depfile-template` or `--depfile-dir` (or both) instead of `--depfile`.